### PR TITLE
Pulling wip/filesys-dir into dev

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,8 @@ module datapond
 Contains that Quart route and global definitions that make up the
 datapond API, a simple Azure Data Lake Gen2 local emulator.
 """
+from os import environ as env
+
 from quart import Quart, request, Response
 
 from datapond.responses import BadRequest, Forbidden, MethodNotAllowed
@@ -12,7 +14,9 @@ from datapond.emulation import Emulator
 # initialize the global Quart app for this datapond and a global
 # data lake emulator instance
 datapond: Quart = Quart(__name__)
-emulator: Emulator = Emulator("./filesystems")
+emulator: Emulator = Emulator(
+    env["DATAPOND_FS_DIR"] if "DATAPOND_FS_DIR" in env else "./filesystems"
+)
 
 
 @datapond.route("/")

--- a/datapond/emulation/emulator.py
+++ b/datapond/emulation/emulator.py
@@ -27,6 +27,14 @@ class Emulator:
         # parse/store the specified container directory
         self._directory = os.path.abspath(container_directory)
 
+        # check if the container directory is the same as the project root
+        if self._directory == os.path.abspath(
+            os.path.join(__file__, os.pardir, os.pardir, os.pardir)
+        ):
+            raise RuntimeError(
+                "The filesystems root directory may not be the same as the project root"
+            )
+
         # check if the container directory exists as a file. throw an exception
         # if this is the case as we don't want to overwrite a directory with a file
         if os.path.isfile(self._directory):


### PR DESCRIPTION
Adds the ability for users to change the filesystems root directory by setting the `DATAPOND_FS_DIR` environment variable.